### PR TITLE
Add image release GH workflows

### DIFF
--- a/.github/workflows/image-publish.yaml
+++ b/.github/workflows/image-publish.yaml
@@ -1,0 +1,25 @@
+---
+name: Publish images
+on:
+  push:
+    branches:
+      - main
+  # Allows releasing on demand.
+  workflow_dispatch:
+
+jobs:
+  publish-log-signer:
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    with:
+      name: trillian-log-signer
+      tag: ${GITHUB_REF_NAME}
+      latest: true
+      dockerfile_path: ./examples/deployment/docker/log_signer/Dockerfile
+
+  publish-log-server:
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    with:
+      name: trillian-log-server
+      tag: ${GITHUB_REF_NAME}
+      latest: true
+      dockerfile_path: ./examples/deployment/docker/log_server/Dockerfile

--- a/examples/deployment/docker/log_server/Dockerfile
+++ b/examples/deployment/docker/log_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-buster as build
+FROM golang:1.19 as build
 
 WORKDIR /trillian
 

--- a/examples/deployment/docker/log_signer/Dockerfile
+++ b/examples/deployment/docker/log_signer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-buster as build
+FROM golang:1.19 as build
 
 WORKDIR /trillian
 


### PR DESCRIPTION
These workflows allow for releasing signed container images on GHCR.
They also allow for releasing on-demand.